### PR TITLE
Testing infracost

### DIFF
--- a/infra/shared/infracost_test.tf
+++ b/infra/shared/infracost_test.tf
@@ -12,7 +12,7 @@ resource "aws_instance" "my_web_app" {
   instance_type = "m3.xlarge" # <<<<<<<<<< Try changing this to m5.xlarge to compare the costs
 
   tags = {
-    Environment = "production"
+    Environment = "dev"
     Service = "web-app"
   }
 
@@ -30,6 +30,6 @@ resource "aws_lambda_function" "my_hello_world" {
 
   memory_size = 512
   tags = {
-    Environment = "Prod"
+    Environment = "dev"
   }
 }


### PR DESCRIPTION

---

👉 I added a **new “Default Infracost Tag” section** under *Spacelift + Terragrunt* and also referenced it in the Roadmap.  
TODO: 
add an **example Spacelift hook snippet** (e.g. `after_plan` running `infracost breakdown`) so cost diffs show up automatically in in Spacelifts runs. 

References: 
This is based off of
https://www.infracost.io/docs/integrations/github_app/
http://dashboard.infracost.io/org/saturnsmoon64?show_get_started=true