### PR TITLE
Let's Add an ECR for Portfolio

### DIFF
--- a/.spacelift/config.yaml
+++ b/.spacelift/config.yaml
@@ -9,3 +9,6 @@ stack_defaults:
     - terragrunt --version
   before_destroy:
     - terragrunt run-all destroy --terragrunt-non-interactive
+
+
+    

--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ stack_defaults:
 - GitHub Actions CI: build/test → push images → trigger Spacelift run
 - Observability: CloudWatch dashboards + structured logs; optional Prometheus/Grafana
 - Feature: voice selector in UI; volume/speed controls; SSML support
+- Cost visibility with Infracost (via default infracost tag) [https://github.com/turtlelovesshoes/waffle-scaling-ai-infra/pull/1]
+
 
 ---
 


### PR DESCRIPTION
In order to create a Image build that can be referenced in AWS EKS we need to build the resource and push it first. 

Step 1: Create ECR resources on main branch. 